### PR TITLE
Add new deal button for dealers to restart rounds early

### DIFF
--- a/src/app/api/tables/[tableGuid]/newdeal/route.ts
+++ b/src/app/api/tables/[tableGuid]/newdeal/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getTable, startNewHand } from '@/lib/tableManager';
+import { generatePokerPlayerAlias } from '@/app/api/tables/playerNamer';
+import { generateTableName } from '@/app/api/tables/tableNamer';
+
+interface Params {
+  params: {
+    tableGuid: string;
+  };
+}
+
+// POST /api/tables/[tableGuid]/newdeal - Start a new deal
+export async function POST(request: NextRequest, { params }: Params) {
+  try {
+    const { tableGuid } = params;
+    console.log(`Received request to start a new deal for table ${tableGuid}`);
+    
+    const table = getTable(tableGuid);
+    
+    if (!table) {
+      return NextResponse.json({ error: 'Table not found' }, { status: 404 });
+    }
+    
+    console.log(`Current game phase for table ${tableGuid}: ${table.gamePhase}`);
+    
+    // Start a new hand
+    const updatedTable = startNewHand(tableGuid);
+    console.log(`Started new deal for table ${tableGuid}, game phase is now: ${updatedTable.gamePhase}`);
+    
+    // Return the updated table
+    return NextResponse.json({
+      table: {
+        ...updatedTable,
+        tableName: generateTableName(updatedTable.tableGuid),
+        // Add player aliases
+        players: updatedTable.players.map(player => ({
+          ...player,
+          playerAlias: generatePokerPlayerAlias(player.playerGuid)
+        })),
+        deck: [], // Don't expose the deck to clients
+        lastUpdated: new Date().toISOString() // Add timestamp for client synchronization
+      }
+    });
+  } catch (error: any) {
+    console.error('Error starting new deal:', error);
+    return NextResponse.json({ error: error.message || 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/lib/tableManager.ts
+++ b/src/lib/tableManager.ts
@@ -200,13 +200,25 @@ function resetToWaitingState(table: Table): void {
   table.gamePhase = 'Waiting';
 }
 
-// Start a new hand - kept for compatibility
-function startNewHand(table: Table): void {
+// Start a new hand - resets the game and immediately deals new cards
+export function startNewHand(tableGuid: string): Table {
+  const table = getTable(tableGuid);
+  
+  if (!table) {
+    throw new Error(`Table with guid ${tableGuid} not found`);
+  }
+  
+  // Reset the table to waiting state
   resetToWaitingState(table);
   
   // Immediately deal cards and advance to pre-flop
   dealPocketCards(table);
   table.gamePhase = 'Pre-Flop';
+  
+  // Save the updated table
+  saveTable(table);
+  
+  return table;
 }
 
 // Remove a player from the table


### PR DESCRIPTION
Adds a button to start a new deal, ending the current round early. Shortcut: `Shift+N`.

This could use some sort of notification or animation in the player view, as now only the Hand ID is updated, making it hard to see that a new round has started. Unless you are actively viewing the cards.


I noticed that responses often call `generateTableName` and `generatePokerPlayerAlias` to set aliases.
These functions are deterministic, so they always return the same values. But these values could have also been stored on the objects or cached on the clients. But perhaps that just add more complexity and storage.

Also, `lastUpdated` is set in the responses, but in the client app it never seems to be used. Instead the clients sets a local `lastUpdated` to `new Date()` when a response is received.